### PR TITLE
Conference schedule current year

### DIFF
--- a/app/espn.tsx
+++ b/app/espn.tsx
@@ -232,11 +232,28 @@ function formatTeamData(teamData: CompetitorData) {
   };
 }
 
+function getCurrentSeasonYear(): number {
+  const now = new Date();
+  const month = now.getMonth(); // 0-indexed: 0 = January, 11 = December
+  const year = now.getFullYear();
+
+  // College basketball season runs from November to April
+  // ESPN uses the later year (e.g., "2026" for the 2025-26 season)
+  // If we're in August-December, the season year is next calendar year
+  // If we're in January-July, the season year is current calendar year
+  if (month >= 7) {
+    // August (7) through December (11)
+    return year + 1;
+  }
+  return year;
+}
+
 export async function getConferenceRankings(): Promise<
   ConferenceRankingEntry[]
 > {
+  const seasonYear = getCurrentSeasonYear();
   const res = await fetch(
-    'https://site.web.api.espn.com/apis/v2/sports/basketball/mens-college-basketball/standings?region=us&lang=en&contentorigin=espn&group=8&season=2025'
+    `https://site.web.api.espn.com/apis/v2/sports/basketball/mens-college-basketball/standings?region=us&lang=en&contentorigin=espn&group=8&season=${seasonYear}`
   );
 
   if (!res.ok) {


### PR DESCRIPTION
Dynamically set the college basketball season year for conference rankings to display current season data.

The previous implementation hardcoded `season=2025`, which was incorrect for the current college basketball season (e.g., 2025-26 season uses `season=2026` in ESPN's API). The `getCurrentSeasonYear` function now calculates the correct season based on the current date, accounting for the November-April season structure where ESPN uses the later year.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9e97750-218d-488d-9956-d8d36de5ccb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9e97750-218d-488d-9956-d8d36de5ccb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only affects how the ESPN standings URL is parameterized and does not alter data processing logic beyond selecting the season year.
> 
> **Overview**
> Conference rankings fetches now dynamically set the ESPN `season` query parameter via a new `getCurrentSeasonYear()` helper (Aug–Dec uses next calendar year), replacing the previously hardcoded `season=2025`.
> 
> No new usage of `componentWillMount`, `eval()`, or `exec()` was introduced, and no TypeScript APIs with easily-swappable same-typed positional args were added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b918152ee7523b6ac04cb58f30b2c2cb07f363d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>b918152</u></sup><!-- /BUGBOT_STATUS -->