### PR TITLE
Cache component stale data

### DIFF
--- a/app/[teamId]/page.tsx
+++ b/app/[teamId]/page.tsx
@@ -1,9 +1,11 @@
 import clsx from 'clsx';
 import Link from 'next/link';
 import Image from 'next/image';
-import { cacheLife } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
 import { getAllTeamIds, getTeamData } from 'app/espn';
 import TeamSelect from './select';
+import { RefreshButton } from 'app/refresh-button';
+import { refreshSchedule } from 'app/actions';
 
 function Row({
   awayScore,
@@ -83,9 +85,9 @@ export default async function HomePage(props: {
   params: Promise<{ teamId: string }>;
 }) {
   'use cache';
-  cacheLife('hours');
-
   const params = await props.params;
+  cacheTag('schedule', `team-${params.teamId}`);
+  cacheLife('hours');
   const [team, allTeams] = await Promise.all([
     getTeamData(params.teamId),
     getAllTeamIds()
@@ -112,7 +114,10 @@ export default async function HomePage(props: {
         </div>
         <h3 className="text-gray-700 dark:text-gray-300 mb-2">{`${record} • ${standing}`}</h3>
         <TeamSelect allTeams={allTeams} teamId={params.teamId} />
-        <h2 className="font-semibold text-xl">Schedule</h2>
+        <div className="flex items-center gap-2">
+          <h2 className="font-semibold text-xl">Schedule</h2>
+          <RefreshButton action={refreshSchedule} />
+        </div>
         <h3 className="font-semibold text-gray-700 dark:text-gray-300 mb-2">
           Full
         </h3>

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -1,0 +1,21 @@
+'use server';
+
+import { updateTag } from 'next/cache';
+
+export async function refreshScores() {
+  updateTag('scores');
+}
+
+export async function refreshSchedule() {
+  updateTag('schedule');
+}
+
+export async function refreshConference() {
+  updateTag('conference');
+}
+
+export async function refreshAll() {
+  updateTag('scores');
+  updateTag('schedule');
+  updateTag('conference');
+}

--- a/app/conference/page.tsx
+++ b/app/conference/page.tsx
@@ -2,7 +2,9 @@ import clsx from 'clsx';
 import Link from 'next/link';
 import Image from 'next/image';
 import { getConferenceRankings } from 'app/espn';
-import { cacheLife } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
+import { RefreshButton } from 'app/refresh-button';
+import { refreshConference } from 'app/actions';
 
 function RankingRow({
   color,
@@ -45,13 +47,17 @@ function RankingRow({
 
 export default async function ConferencePage() {
   'use cache';
+  cacheTag('conference');
   cacheLife('minutes');
 
   const confRankings = await getConferenceRankings();
 
   return (
     <section className="w-full mx-auto p-6">
-      <h2 className="font-semibold text-2xl">Conference</h2>
+      <div className="flex items-center gap-2">
+        <h2 className="font-semibold text-2xl">Conference</h2>
+        <RefreshButton action={refreshConference} />
+      </div>
       <h3 className="text-sm text-gray-700 dark:text-gray-300 mb-2 flex justify-end">
         GB
       </h3>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,10 +2,12 @@ import clsx from 'clsx';
 import Link from 'next/link';
 import Image from 'next/image';
 import { getAllTeamIds, getTeamData } from 'app/espn';
-import { cacheLife } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
 import TeamSelect from './[teamId]/select';
 import ConferencePage from './conference/page';
 import ScoresPage from './scores/page';
+import { RefreshButton } from './refresh-button';
+import { refreshSchedule } from './actions';
 
 function Row({
   awayScore,
@@ -75,6 +77,7 @@ function Row({
 
 async function Schedule() {
   'use cache';
+  cacheTag('schedule', 'team-66');
   cacheLife('hours');
 
   const [team, allTeams] = await Promise.all([
@@ -106,7 +109,10 @@ async function Schedule() {
       </div>
       <h3 className="text-gray-700 dark:text-gray-300 mb-2">{`${record} • ${standing}`}</h3>
       <TeamSelect allTeams={allTeams} teamId={'66'} />
-      <h2 className="font-semibold text-xl">Schedule</h2>
+      <div className="flex items-center gap-2">
+        <h2 className="font-semibold text-xl">Schedule</h2>
+        <RefreshButton action={refreshSchedule} />
+      </div>
       <h3 className="font-semibold text-gray-700 dark:text-gray-300">Next</h3>
       {nextGame && <Row isLast {...nextGame} />}
       <h3 className="font-semibold text-gray-700 dark:text-gray-300 mt-4">

--- a/app/refresh-button.tsx
+++ b/app/refresh-button.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { RefreshCwIcon } from 'lucide-react';
+import { useTransition } from 'react';
+
+export function RefreshButton({ action }: { action: () => Promise<void> }) {
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <button
+      onClick={() => startTransition(() => action())}
+      disabled={isPending}
+      aria-label="Refresh data"
+      className="p-1 rounded-md text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-900 disabled:opacity-50 transition-colors"
+    >
+      <RefreshCwIcon
+        className={`h-4 w-4 ${isPending ? 'animate-spin' : ''}`}
+      />
+    </button>
+  );
+}

--- a/app/scores/page.tsx
+++ b/app/scores/page.tsx
@@ -1,6 +1,8 @@
 import { Scores } from './scores';
 import { Suspense } from 'react';
 import clsx from 'clsx';
+import { RefreshButton } from 'app/refresh-button';
+import { refreshScores } from 'app/actions';
 
 function TeamSkeleton() {
   return (
@@ -46,7 +48,10 @@ function ScoresLoading() {
 export default function ScoresPage() {
   return (
     <section className="w-full mx-auto p-6">
-      <h2 className="font-semibold text-2xl">Scores</h2>
+      <div className="flex items-center gap-2">
+        <h2 className="font-semibold text-2xl">Scores</h2>
+        <RefreshButton action={refreshScores} />
+      </div>
       <Suspense fallback={<ScoresLoading />}>
         <Scores />
       </Suspense>

--- a/app/scores/scores.tsx
+++ b/app/scores/scores.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
 import { getTodaySchedule } from 'app/espn';
-import { cacheLife } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
 
 function Team({
   color,
@@ -72,6 +72,7 @@ function Team({
 
 export async function Scores() {
   'use cache';
+  cacheTag('scores');
   cacheLife('minutes');
 
   const { games } = await getTodaySchedule();


### PR DESCRIPTION
Implement `cacheTag` and `updateTag` with UI refresh buttons to resolve stale data issues for cached components.

The existing `cacheLife('hours')` strategy, while effective for frequent visitors, meant that infrequent users (visiting days or weeks later) would consistently encounter stale data due to the stale-while-revalidate mechanism. By adding `cacheTag` to components and `updateTag` via Server Actions, we enable immediate, on-demand cache invalidation, ensuring users can always retrieve the latest data.

---
<p><a href="https://cursor.com/agents/bc-e080e5d3-3be7-4aea-9c40-07e915b3f6a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e080e5d3-3be7-4aea-9c40-07e915b3f6a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

